### PR TITLE
カード名の変更時に、元画面のカード名が変更されないのを修正

### DIFF
--- a/app/views/cards/update.js.erb
+++ b/app/views/cards/update.js.erb
@@ -2,6 +2,8 @@ var target = $('.card-id-<%= @card.id %>');
 target.find('.card-name').html('<%= @card.name %>');
 target.find('.card-name').removeClass('hidden');
 target.find('.card-name__form').removeClass('is-shown');
+target.prev().html('<%= @card.name %>');
+
 var details = "<%= @card.details %>";
 
 function hiddenForm() {


### PR DESCRIPTION
# WHAT
カード名を修正した時に、リスト表示している画面のカード名は変更されない。（モーダル画面は変更される）
これを変更されるように修正する。

# WHY
カード名変更が反映されない不良修正