### PR TITLE
[WIP]リファクタリング

### DIFF
--- a/app/assets/javascripts/list.js
+++ b/app/assets/javascripts/list.js
@@ -35,8 +35,16 @@ $(document).on('turbolinks:load', function() {
     });
 
     $(this).find('.list-edit-form').blur(function() {
-      $(this).parent().parent().prev().removeClass('hidden');
-      $(this).parent().parent().removeClass('is-shown');
+      var flg = true;
+      jQuery(":hover").each(function() {
+        if ($(this).hasClass('list-delete-button__link')) {
+          flg = false;
+        }
+      });
+      if (flg) {
+        $(this).parent().parent().prev().removeClass('hidden');
+        $(this).parent().parent().removeClass('is-shown');
+      }
     });
 
     $(this).find('.edit_list').on('submit', function() {

--- a/app/views/cards/create.js.erb
+++ b/app/views/cards/create.js.erb
@@ -98,7 +98,7 @@ $('.lists__item__content').sortable({
     $('.lists__item').each(function() {
       if ($(this).find('.card').length > 2) {
         $(this).find('.hiddena').remove();
-      } else if ($(this).find('.card').length == 1) {
+      } else if ($(this).find('.card').length == 1　&& $(this).find('.hiddena').length == 0) {
         $(this).find('.lists__item__content').prepend('<div class="card hiddena"><div class="lists__item__content__card"></div></div>');
       }
     });

--- a/app/views/lists/create.js.erb
+++ b/app/views/lists/create.js.erb
@@ -16,8 +16,16 @@ $.each($('.lists__item__newlink'), function() {
   });
 
   $(this).parent().find('.list-edit-form').blur(function() {
-    $(this).parent().parent().prev().removeClass('hidden');
-    $(this).parent().parent().removeClass('is-shown');
+    var flg = true;
+    jQuery(":hover").each(function() {
+      if ($(this).hasClass('list-delete-button__link')) {
+        flg = false;
+      }
+    });
+    if (flg) {
+      $(this).parent().parent().prev().removeClass('hidden');
+      $(this).parent().parent().removeClass('is-shown');
+    }
   });
 
   $(this).parent().find('.edit_list').on('submit', function() {

--- a/app/views/lists/create.js.erb
+++ b/app/views/lists/create.js.erb
@@ -41,6 +41,7 @@ $('.card-close').each(function() {
 $('.lists').sortable({
   items: $('.lists__item:not(:last-child)'),
   tolerance: "pointer",
+  handle: $('.lists__item__header'),
   update: function(e, ui) {
     item = ui.item;
     item_data = item.data();


### PR DESCRIPTION
# WHAT
リストが削除できないバグを修正する。
原因は、リスト名のテキストフィールドからフォーカスアウトした時に、フォームが消えるようになっているから。
対応方法として、フォーカスアウトした時に、マウスカーソルが削除ボタン上にあればフォームを消さないようにする。

# WHY
リストが消さないため、修正必要。